### PR TITLE
Change xmpp.org links for HTTPS ones

### DIFF
--- a/rfc6120.xml
+++ b/rfc6120.xml
@@ -6682,7 +6682,7 @@ Public-key and attribute certificate frameworks</title>
     <date month="March" year="2010"/>
   </front>
   <seriesInfo name="XSF XEP" value="0001"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0001.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0001.html"/>
 </reference>
 
 <reference anchor="XEP-0016">
@@ -6701,7 +6701,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="15" month="February" year="2007"/>
   </front>
   <seriesInfo name="XSF XEP" value="0016"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0016.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0016.html"/>
 </reference>
 
 <reference anchor="XEP-0045">
@@ -6716,7 +6716,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="17" month="July" year="2007"/>
   </front>
   <seriesInfo name="XSF XEP" value="0045"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0045.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0045.html"/>
 </reference>
 
 <reference anchor="XEP-0060">
@@ -6743,7 +6743,7 @@ Public-key and attribute certificate frameworks</title>
     <date month="July" year="2010"/>
   </front>
   <seriesInfo name="XSF XEP" value="0060"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0060.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0060.html"/>
 </reference>
 
 <reference anchor="XEP-0071">
@@ -6758,7 +6758,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="3" month="September" year="2008"/>
   </front>
   <seriesInfo name="XSF XEP" value="0071"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0071.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0071.html"/>
 </reference>
 
 <reference anchor="XEP-0077">
@@ -6773,7 +6773,7 @@ Public-key and attribute certificate frameworks</title>
     <date month="September" year="2009"/>
   </front>
   <seriesInfo name="XSF XEP" value="0077"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0077.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0077.html"/>
 </reference>
 
 <reference anchor="XEP-0086">
@@ -6794,7 +6794,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="17" month="February" year="2004"/>
   </front>
   <seriesInfo name="XSF XEP" value="0086"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0086.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0086.html"/>
 </reference>
 
 <reference anchor="XEP-0100">
@@ -6815,7 +6815,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="05" month="October" year="2005"/>
   </front>
   <seriesInfo name="XSF XEP" value="0100"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0100.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0100.html"/>
 </reference>
 
 <reference anchor="XEP-0114">
@@ -6830,7 +6830,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="03" month="March" year="2005"/>
   </front>
   <seriesInfo name="XSF XEP" value="0114"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0114.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0114.html"/>
 </reference>
 
 <reference anchor="XEP-0124">
@@ -6857,7 +6857,7 @@ Public-key and attribute certificate frameworks</title>
     <date month="July" year="2010"/>
   </front>
   <seriesInfo name="XSF XEP" value="0124"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0124.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0124.html"/>
 </reference>
 
 <reference anchor="XEP-0138">
@@ -6878,7 +6878,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="27" month="May" year="2009"/>
   </front>
   <seriesInfo name="XSF XEP" value="0138"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0138.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0138.html"/>
 </reference>
 
 <reference anchor="XEP-0156">
@@ -6899,7 +6899,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="12" month="June" year="2007"/>
   </front>
   <seriesInfo name="XSF XEP" value="0156"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0156.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0156.html"/>
 </reference>
 
 <reference anchor="XEP-0160">
@@ -6914,7 +6914,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="24" month="January" year="2006"/>
   </front>
   <seriesInfo name="XSF XEP" value="0160"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0160.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0160.html"/>
 </reference>
 
 <reference anchor="XEP-0174">
@@ -6929,7 +6929,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="26" month="November" year="2008"/>
   </front>
   <seriesInfo name="XSF XEP" value="0174"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0174.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0174.html"/>
 </reference>
 
 <reference anchor="XEP-0175">
@@ -6944,7 +6944,7 @@ Public-key and attribute certificate frameworks</title>
     <date month="September" year="2009"/>
   </front>
   <seriesInfo name="XSF XEP" value="0175"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0175.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0175.html"/>
 </reference>
 
 <reference anchor="XEP-0178">
@@ -6965,7 +6965,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="15" month="February" year="2007"/>
   </front>
   <seriesInfo name="XSF XEP" value="0178"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0178.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0178.html"/>
 </reference>
 
 <reference anchor="XEP-0191">
@@ -6980,7 +6980,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="15" month="February" year="2007"/>
   </front>
   <seriesInfo name="XSF XEP" value="0191"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0191.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0191.html"/>
 </reference>
 
 <reference anchor="XEP-0198">
@@ -7019,7 +7019,7 @@ Public-key and attribute certificate frameworks</title>
     <date month="February" year="2011"/>
   </front>
   <seriesInfo name="XSF XEP" value="0198"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0198.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0198.html"/>
 </reference>
 
 <reference anchor="XEP-0199">
@@ -7034,7 +7034,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="03" month="June" year="2009"/>
   </front>
   <seriesInfo name="XSF XEP" value="0199"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0199.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0199.html"/>
 </reference>
 
 <reference anchor="XEP-0205">
@@ -7049,7 +7049,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="7" month="January" year="2009"/>
   </front>
   <seriesInfo name="XSF XEP" value="0205"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0205.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0205.html"/>
 </reference>
 
 <reference anchor="XEP-0206">
@@ -7070,7 +7070,7 @@ Public-key and attribute certificate frameworks</title>
     <date month="July" year="2010"/>
   </front>
   <seriesInfo name="XSF XEP" value="0206"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0206.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0206.html"/>
 </reference>
 
 <reference anchor="XEP-0220">
@@ -7097,7 +7097,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="18" month="March" year="2010"/>
   </front>
   <seriesInfo name="XSF XEP" value="0220"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0220.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0220.html"/>
 </reference>
 
 <reference anchor="XEP-0225">
@@ -7112,7 +7112,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="06" month="October" year="2008"/>
   </front>
   <seriesInfo name="XSF XEP" value="0225"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0225.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0225.html"/>
 </reference>
 
 <reference anchor="XEP-0233">
@@ -7139,7 +7139,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="10" month="June" year="2010"/>
   </front>
   <seriesInfo name="XSF XEP" value="0233"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0233.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0233.html"/>
 </reference>
 
 <reference anchor="XEP-0288">
@@ -7160,7 +7160,7 @@ Public-key and attribute certificate frameworks</title>
     <date day="04" month="October" year="2010"/>
   </front>
   <seriesInfo name="XSF XEP" value="0288"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0288.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0288.html"/>
 </reference>
 
 <reference anchor='XML-FRAG'

--- a/rfc6121.xml
+++ b/rfc6121.xml
@@ -2828,7 +2828,7 @@ US: </stream:stream>
     <date day="15" month="September" year="2009"/>
   </front>
   <seriesInfo name="XSF XEP" value="0203"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0203.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0203.html"/>
 </reference>
 
 <reference anchor="KEYWORDS">
@@ -3359,7 +3359,7 @@ US: </stream:stream>
     <date day="15" month="February" year="2007"/>
   </front>
   <seriesInfo name="XSF XEP" value="0016"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0016.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0016.html"/>
 </reference>
 
 <reference anchor="XEP-0045">
@@ -3374,7 +3374,7 @@ US: </stream:stream>
     <date day="16" month="July" year="2008"/>
   </front>
   <seriesInfo name="XSF XEP" value="0045"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0045.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0045.html"/>
 </reference>
 
 <reference anchor="XEP-0054">
@@ -3389,7 +3389,7 @@ US: </stream:stream>
     <date day="16" month="July" year="2008"/>
   </front>
   <seriesInfo name="XSF XEP" value="0054"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0054.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0054.html"/>
 </reference>
 
 <reference anchor="XEP-0071">
@@ -3404,7 +3404,7 @@ US: </stream:stream>
     <date day="3" month="September" year="2008"/>
   </front>
   <seriesInfo name="XSF XEP" value="0071"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0071.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0071.html"/>
 </reference>
 
 <reference anchor="XEP-0115">
@@ -3431,7 +3431,7 @@ US: </stream:stream>
     <date day="26" month="February" year="2008"/>
   </front>
   <seriesInfo name="XSF XEP" value="0115"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0115.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0115.html"/>
 </reference>
 
 <reference anchor="XEP-0147">
@@ -3446,7 +3446,7 @@ US: </stream:stream>
     <date day="13" month="September" year="2006"/>
   </front>
   <seriesInfo name="XSF XEP" value="0147"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0147.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0147.html"/>
 </reference>
 
 <reference anchor="XEP-0160">
@@ -3461,7 +3461,7 @@ US: </stream:stream>
     <date day="24" month="January" year="2006"/>
   </front>
   <seriesInfo name="XSF XEP" value="0160"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0160.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0160.html"/>
 </reference>
 
 <reference anchor="XEP-0163">
@@ -3482,7 +3482,7 @@ US: </stream:stream>
     <date day="12" month="July" year="2010"/>
   </front>
   <seriesInfo name="XSF XEP" value="0163"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0163.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0163.html"/>
 </reference>
 
 <reference anchor="XEP-0191">
@@ -3497,7 +3497,7 @@ US: </stream:stream>
     <date day="15" month="February" year="2007"/>
   </front>
   <seriesInfo name="XSF XEP" value="0191"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0191.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0191.html"/>
 </reference>
 
 <reference anchor="XEP-0201">
@@ -3524,7 +3524,7 @@ US: </stream:stream>
     <date month="November" year="2010"/>
   </front>
   <seriesInfo name="XSF XEP" value="0201"/>
-  <format type="HTML" target="http://www.xmpp.org/extensions/xep-0201.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0201.html"/>
 </reference>
 
 <reference anchor="XEP-0237">
@@ -3545,7 +3545,7 @@ US: </stream:stream>
     <date day="5" month="March" year="2010"/>
   </front>
   <seriesInfo name="XSF XEP" value="0237"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0237.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0237.html"/>
 </reference>
 
 <reference anchor="XML-DATATYPES"

--- a/rfc7395.xml
+++ b/rfc7395.xml
@@ -832,11 +832,11 @@ C: <open xmlns="urn:ietf:params:xml:ns:xmpp-framing"
 <seriesInfo name='RFC' value='6454' />
 </reference>
 
-   <?rfc include="http://xmpp.org/extensions/refs/reference.XSF.XEP-0124.xml"?>
-   <?rfc include="http://xmpp.org/extensions/refs/reference.XSF.XEP-0156.xml"?>
-   <?rfc include="http://xmpp.org/extensions/refs/reference.XSF.XEP-0198.xml"?>
-   <?rfc include="http://xmpp.org/extensions/refs/reference.XSF.XEP-0199.xml"?>
-   <?rfc include="http://xmpp.org/extensions/refs/reference.XSF.XEP-0206.xml"?>
+   <?rfc include="https://xmpp.org/extensions/refs/reference.XSF.XEP-0124.xml"?>
+   <?rfc include="https://xmpp.org/extensions/refs/reference.XSF.XEP-0156.xml"?>
+   <?rfc include="https://xmpp.org/extensions/refs/reference.XSF.XEP-0198.xml"?>
+   <?rfc include="https://xmpp.org/extensions/refs/reference.XSF.XEP-0199.xml"?>
+   <?rfc include="https://xmpp.org/extensions/refs/reference.XSF.XEP-0206.xml"?>
 
 <reference anchor='XML-SCHEMA'
            target='http://www.w3.org/TR/2004/REC-xmlschema-1-20041028'>

--- a/rfc7590.xml
+++ b/rfc7590.xml
@@ -217,7 +217,7 @@ http://www.rfc-editor.org/errata_search.php?eid=3486
         <seriesInfo name="Work in Progress," value="draft-ietf-xmpp-posh-04"/>
       </reference>
 
-<reference anchor="XEP-0138" target="http://xmpp.org/extensions/xep-0138.html" >
+<reference anchor="XEP-0138" target="https://xmpp.org/extensions/xep-0138.html" >
   <front>
     <title>Stream Compression</title>
     <author initials="J." surname="Hildebrand" fullname="Joe Hildebrand">
@@ -237,7 +237,7 @@ http://www.rfc-editor.org/errata_search.php?eid=3486
   <seriesInfo name="XSF XEP" value="0138"/>
 </reference>
 
-<reference anchor="XEP-0170" target="http://xmpp.org/extensions/xep-0170.html">
+<reference anchor="XEP-0170" target="https://xmpp.org/extensions/xep-0170.html">
   <front>
     <title>Recommended Order of Stream Feature Negotiation</title>
     <author initials="P." surname="Saint-Andre" fullname="Peter Saint-Andre">
@@ -251,7 +251,7 @@ http://www.rfc-editor.org/errata_search.php?eid=3486
   <seriesInfo name="XSF XEP" value="0170"/>
 </reference>
 
-<reference anchor="XEP-0198" target="http://xmpp.org/extensions/xep-0198.html">
+<reference anchor="XEP-0198" target="https://xmpp.org/extensions/xep-0198.html">
   <front>
     <title>Stream Management</title>
     <author initials="J." surname="Karneges" fullname="Justin Karneges">
@@ -295,7 +295,7 @@ http://www.rfc-editor.org/errata_search.php?eid=3486
   <seriesInfo name="XSF XEP" value="0198"/>
 </reference>
 
-<reference anchor="XEP-0220" target="http://xmpp.org/extensions/xep-0220.html">
+<reference anchor="XEP-0220" target="https://xmpp.org/extensions/xep-0220.html">
   <front>
     <title>Server Dialback</title>
     <author initials="J." surname="Miller" fullname="Jeremie Miller">

--- a/rfc7622.xml
+++ b/rfc7622.xml
@@ -1015,7 +1015,7 @@ Representing Nicknames</title>
  <seriesInfo name='edited by Mark Davis' value='and Michel Suignard'/>
 </reference>
 
-<reference anchor="XEP-0004" target="http://xmpp.org/extensions/xep-0004.html">
+<reference anchor="XEP-0004" target="https://xmpp.org/extensions/xep-0004.html">
   <front>
     <title>Data Forms</title>
     <author initials="R." surname="Eatmon" fullname="Ryan Eatmon">
@@ -1053,7 +1053,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0004"/>
 </reference>
 
-<reference anchor="XEP-0016" target="http://xmpp.org/extensions/xep-0016.html">
+<reference anchor="XEP-0016" target="https://xmpp.org/extensions/xep-0016.html">
   <front>
     <title>Privacy Lists</title>
     <author initials="P." surname="Millard" fullname="Peter Millard">
@@ -1073,7 +1073,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0016"/>
 </reference>
 
-<reference anchor="XEP-0029" target="http://xmpp.org/extensions/xep-0029.html">
+<reference anchor="XEP-0029" target="https://xmpp.org/extensions/xep-0029.html">
   <front>
     <title>Definition of Jabber Identifiers (JIDs)</title>
     <author initials="C." surname="Kaes" fullname="Craig Kaes">
@@ -1087,7 +1087,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0029"/>
 </reference>
 
-<reference anchor="XEP-0030" target="http://xmpp.org/extensions/xep-0030.html">
+<reference anchor="XEP-0030" target="https://xmpp.org/extensions/xep-0030.html">
   <front>
     <title>Service Discovery</title>
     <author initials="J." surname="Hildebrand" fullname="Joe Hildebrand">
@@ -1119,7 +1119,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0030"/>
 </reference>
 
-<reference anchor="XEP-0045" target="http://xmpp.org/extensions/xep-0045.html">
+<reference anchor="XEP-0045" target="https://xmpp.org/extensions/xep-0045.html">
   <front>
     <title>Multi-User Chat</title>
     <author initials="P." surname="Saint-Andre" fullname="Peter Saint-Andre">
@@ -1133,7 +1133,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0045"/>
 </reference>
 
-<reference anchor="XEP-0048" target="http://xmpp.org/extensions/xep-0048.html">
+<reference anchor="XEP-0048" target="https://xmpp.org/extensions/xep-0048.html">
   <front>
     <title>Bookmarks</title>
     <author initials="R." surname="Blackman" fullname="Rachel Blackman">
@@ -1159,7 +1159,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0048"/>
 </reference>
 
-<reference anchor="XEP-0054" target="http://xmpp.org/extensions/xep-0054.html">
+<reference anchor="XEP-0054" target="https://xmpp.org/extensions/xep-0054.html">
   <front>
     <title>vcard-temp</title>
     <author initials="P." surname="Saint-Andre" fullname="Peter Saint-Andre">
@@ -1171,10 +1171,10 @@ Representing Nicknames</title>
     <date month="July" year="2008"/>
   </front>
   <seriesInfo name="XSF XEP" value="0054"/>
-  <format type="HTML" target="http://xmpp.org/extensions/xep-0054.html"/>
+  <format type="HTML" target="https://xmpp.org/extensions/xep-0054.html"/>
 </reference>
 
-<reference anchor="XEP-0060" target="http://xmpp.org/extensions/xep-0060.html">
+<reference anchor="XEP-0060" target="https://xmpp.org/extensions/xep-0060.html">
   <front>
     <title>Publish-Subscribe</title>
     <author initials="P." surname="Millard" fullname="Peter Millard">
@@ -1200,7 +1200,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0060"/>
 </reference>
 
-<reference anchor="XEP-0065" target="http://xmpp.org/extensions/xep-0065.html">
+<reference anchor="XEP-0065" target="https://xmpp.org/extensions/xep-0065.html">
   <front>
     <title>SOCKS5 Bytestreams</title>
     <author initials="D." surname="Smith" fullname="Dave Smith">
@@ -1232,7 +1232,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0065"/>
 </reference>
 
-<reference anchor="XEP-0077" target="http://xmpp.org/extensions/xep-0077.html">
+<reference anchor="XEP-0077" target="https://xmpp.org/extensions/xep-0077.html">
   <front>
     <title>In-Band Registration</title>
     <author initials="P." surname="Saint-Andre" fullname="Peter Saint-Andre">
@@ -1246,7 +1246,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0077"/>
 </reference>
 
-<reference anchor="XEP-0106" target="http://xmpp.org/extensions/xep-0106.html">
+<reference anchor="XEP-0106" target="https://xmpp.org/extensions/xep-0106.html">
   <front>
     <title>JID Escaping</title>
     <author initials="J." surname="Hildebrand" fullname="Joe Hildebrand">
@@ -1266,7 +1266,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0106"/>
 </reference>
 
-<reference anchor="XEP-0114" target="http://xmpp.org/extensions/xep-0114.html">
+<reference anchor="XEP-0114" target="https://xmpp.org/extensions/xep-0114.html">
   <front>
     <title>Jabber Component Protocol</title>
     <author initials="P." surname="Saint-Andre" fullname="Peter Saint-Andre">
@@ -1280,7 +1280,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0114"/>
 </reference>
 
-<reference anchor="XEP-0144" target="http://xmpp.org/extensions/xep-0144.html">
+<reference anchor="XEP-0144" target="https://xmpp.org/extensions/xep-0144.html">
   <front>
     <title>Roster Item Exchange</title>
     <author initials="P." surname="Saint-Andre" fullname="Peter Saint-Andre">
@@ -1294,7 +1294,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0144"/>
 </reference>
 
-<reference anchor="XEP-0166" target="http://xmpp.org/extensions/xep-0166.html">
+<reference anchor="XEP-0166" target="https://xmpp.org/extensions/xep-0166.html">
   <front>
     <title>Jingle</title>
     <author initials="S." surname="Ludwig" fullname="Scott Ludwig">
@@ -1338,7 +1338,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0166"/>
 </reference>
 
-<reference anchor="XEP-0191" target="http://xmpp.org/extensions/xep-0191.html">
+<reference anchor="XEP-0191" target="https://xmpp.org/extensions/xep-0191.html">
   <front>
     <title>Blocking Command</title>
     <author initials="P." surname="Saint-Andre" fullname="Peter Saint-Andre">
@@ -1352,7 +1352,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0191"/>
 </reference>
 
-<reference anchor="XEP-0203" target="http://xmpp.org/extensions/xep-0203.html">
+<reference anchor="XEP-0203" target="https://xmpp.org/extensions/xep-0203.html">
   <front>
     <title>Delayed Delivery</title>
     <author initials="P." surname="Saint-Andre" fullname="Peter Saint-Andre">
@@ -1366,7 +1366,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0203"/>
 </reference>
 
-<reference anchor="XEP-0220" target="http://xmpp.org/extensions/xep-0220.html">
+<reference anchor="XEP-0220" target="https://xmpp.org/extensions/xep-0220.html">
   <front>
     <title>Server Dialback</title>
     <author initials="J." surname="Miller" fullname="Jeremie Miller">
@@ -1392,7 +1392,7 @@ Representing Nicknames</title>
   <seriesInfo name="XSF XEP" value="0220"/>
 </reference>
 
-<reference anchor="XEP-0292" target="http://xmpp.org/extensions/xep-0292.html">
+<reference anchor="XEP-0292" target="https://xmpp.org/extensions/xep-0292.html">
   <front>
     <title>vCard4 Over XMPP</title>
     <author initials="P." surname="Saint-Andre" fullname="Peter Saint-Andre">

--- a/rfc7712.xml
+++ b/rfc7712.xml
@@ -1097,7 +1097,7 @@ _xmpp-server._tcp.example.com. 0 IN SRV 0 0 5269 hosting.example.net
 <!-- draft-ietf-dane-srv (published; RFC 7673) -->
       &rfc7673;
 
-<reference anchor="XEP-0220" target="http://xmpp.org/extensions/xep-0220.html">
+<reference anchor="XEP-0220" target="https://xmpp.org/extensions/xep-0220.html">
   <front>
     <title>Server Dialback</title>
     <author initials="J." surname="Miller" fullname="Jeremie Miller">
@@ -1125,7 +1125,7 @@ _xmpp-server._tcp.example.com. 0 IN SRV 0 0 5269 hosting.example.net
       &rfc6749;
       &rfc7590;
 
-<reference anchor="XEP-0045" target="http://xmpp.org/extensions/xep-0045.html">
+<reference anchor="XEP-0045" target="https://xmpp.org/extensions/xep-0045.html">
   <front>
     <title>Multi-User Chat</title>
     <author initials="P." surname="Saint-Andre" fullname="Peter Saint-Andre">
@@ -1136,7 +1136,7 @@ _xmpp-server._tcp.example.com. 0 IN SRV 0 0 5269 hosting.example.net
   <seriesInfo name="XSF XEP" value="0045"/>
 </reference>
 
-<reference anchor="XEP-0288" target="http://xmpp.org/extensions/xep-0288.html">
+<reference anchor="XEP-0288" target="https://xmpp.org/extensions/xep-0288.html">
   <front>
     <title>Bidirectional Server-to-Server Connections</title>
     <author initials="P." surname="Hancke" fullname="Philipp Hancke">
@@ -1150,7 +1150,7 @@ _xmpp-server._tcp.example.com. 0 IN SRV 0 0 5269 hosting.example.net
   <seriesInfo name="XSF XEP" value="0288"/>
 </reference>
 
-<reference anchor="XEP-0344" target="http://xmpp.org/extensions/xep-0344.html">
+<reference anchor="XEP-0344" target="https://xmpp.org/extensions/xep-0344.html">
   <front>
     <title>Impact of TLS and DNSSEC on Dialback</title>
     <author initials="P." surname="Hancke" fullname="Philipp Hancke">


### PR DESCRIPTION
This matches their current canonical URL, and avoids issues where an attacker strips the first HTTPS redirection.